### PR TITLE
feat: Implement org creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@
 
 export { AuthorityClient } from './lib/client/AuthorityClient.js';
 export type { AuthorizationHeader } from './lib/client/AuthorizationHeader.js';
+
+export * from './lib/commands/orgCreation.js';

--- a/src/lib/commands/orgCreation.spec.ts
+++ b/src/lib/commands/orgCreation.spec.ts
@@ -1,0 +1,87 @@
+import { getJsonValue, makeJsonResponse } from '../../testUtils/jsonSerialisation.js';
+import { ORG_NAME } from '../../testUtils/stubs.js';
+import { SerialisationError } from '../utils/serialisation/SerialisationError.js';
+
+import {
+  OrgCreationCommand,
+  type OrgCreationInput,
+  type OrgCreationOutput,
+} from './orgCreation.js';
+
+const INPUT: OrgCreationInput = { name: ORG_NAME };
+
+const OUTPUT: OrgCreationOutput = {
+  self: `/orgs/${ORG_NAME}`,
+  members: `/orgs/${ORG_NAME}/members`,
+};
+
+describe('OrgCreationCommand', () => {
+  describe('responseDeserialiser', () => {
+    test.each<keyof typeof OUTPUT>(['self', 'members'])(
+      '%s URL path should be returned',
+      async (pathName) => {
+        const command = new OrgCreationCommand(INPUT);
+        const output = { ...OUTPUT, [pathName]: undefined };
+        const response = makeJsonResponse(output);
+
+        await expect(command.responseDeserialiser.deserialise(response)).rejects.toThrow(
+          SerialisationError,
+        );
+      },
+    );
+
+    test('Valid response body should be returned', async () => {
+      const command = new OrgCreationCommand(INPUT);
+      const response = makeJsonResponse(OUTPUT);
+
+      const output = await command.responseDeserialiser.deserialise(response);
+
+      expect(output).toMatchObject(OUTPUT);
+    });
+  });
+
+  describe('getRequest', () => {
+    test('Method should be post', () => {
+      const command = new OrgCreationCommand(INPUT);
+
+      const { method } = command.getRequest();
+
+      expect(method).toBe('POST');
+    });
+
+    test('Content type should be undefined', () => {
+      const command = new OrgCreationCommand(INPUT);
+
+      const { contentType } = command.getRequest();
+
+      expect(contentType).toBeUndefined();
+    });
+
+    test('Path should be /orgs', () => {
+      const command = new OrgCreationCommand(INPUT);
+
+      const { path } = command.getRequest();
+
+      expect(path).toBe('/orgs');
+    });
+
+    test('Body should contain org name', () => {
+      const command = new OrgCreationCommand(INPUT);
+
+      const { body } = command.getRequest();
+
+      const value = getJsonValue(body) as OrgCreationInput;
+      expect(value.name).toBe(ORG_NAME);
+    });
+  });
+
+  describe('getOutput', () => {
+    test('Response body should be returned as is', () => {
+      const command = new OrgCreationCommand(INPUT);
+
+      const output = command.getOutput(OUTPUT);
+
+      expect(output).toBe(OUTPUT);
+    });
+  });
+});

--- a/src/lib/commands/orgCreation.ts
+++ b/src/lib/commands/orgCreation.ts
@@ -1,0 +1,41 @@
+import type { PostRequest } from '../utils/requests.js';
+import { JsonValue } from '../utils/serialisation/JsonValue.js';
+import { JsonDeserialiser } from '../utils/serialisation/JsonDeserialiser.js';
+import { compileSchema } from '../utils/serialisation/jsonSchema.js';
+
+import { Command } from './Command.js';
+
+const VALIDATOR = compileSchema({
+  type: 'object',
+  properties: { self: { type: 'string' }, members: { type: 'string' } },
+  required: ['self', 'members'],
+} as const);
+
+export interface OrgCreationInput {
+  name: string;
+}
+
+export interface OrgCreationOutput {
+  self: string;
+  members: string;
+}
+
+export class OrgCreationCommand extends Command<
+  OrgCreationInput,
+  OrgCreationOutput,
+  OrgCreationOutput
+> {
+  public responseDeserialiser = new JsonDeserialiser(VALIDATOR);
+
+  public override getRequest(): PostRequest {
+    return {
+      method: 'POST',
+      path: '/orgs',
+      body: new JsonValue(this.input),
+    };
+  }
+
+  public override getOutput(responseBody: OrgCreationOutput): OrgCreationOutput {
+    return responseBody;
+  }
+}

--- a/src/lib/utils/serialisation/JsonDeserialiser.ts
+++ b/src/lib/utils/serialisation/JsonDeserialiser.ts
@@ -1,9 +1,9 @@
 import type { Deserialiser } from './Deserialiser.js';
 import { SerialisationError } from './SerialisationError.js';
 
-const JSON_CONTENT_TYPE = 'application/json';
-
 type SchemaValidator<Type> = (data: unknown) => data is Type;
+
+export const JSON_CONTENT_TYPE = 'application/json';
 
 export class JsonDeserialiser<Type> implements Deserialiser<Type> {
   public constructor(protected readonly validator: SchemaValidator<Type>) {}

--- a/src/testUtils/jsonSerialisation.ts
+++ b/src/testUtils/jsonSerialisation.ts
@@ -1,0 +1,14 @@
+import type { SerialisableValue } from '../lib/utils/serialisation/SerialisableValue.js';
+import { JsonValue } from '../lib/utils/serialisation/JsonValue.js';
+import { JSON_CONTENT_TYPE } from '../lib/utils/serialisation/JsonDeserialiser.js';
+
+export function makeJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: new Headers([['Content-Type', JSON_CONTENT_TYPE]]),
+  });
+}
+
+export function getJsonValue(value: SerialisableValue): unknown {
+  expect(value).toBeInstanceOf(JsonValue);
+  return (value as JsonValue<unknown>).value;
+}

--- a/src/testUtils/stubs.ts
+++ b/src/testUtils/stubs.ts
@@ -1,0 +1,1 @@
+export const ORG_NAME = 'example.com';


### PR DESCRIPTION
I tested it against a running Authority server instance as follows:

```ts
import { stringify } from 'node:querystring';

import type { AuthorizationHeader } from './client/AuthorizationHeader.js';
import { AuthorityClient } from './client/AuthorityClient.js';
import { OrgCreationCommand } from './commands/orgCreation.js';

const API_URL = 'http://veraid-authority.default.10.103.177.106.sslip.io';

const AUTH_ENDPOINT_URL = 'http://mock-authz-server.default.10.103.177.106.sslip.io/default/token';

const ADMIN_EMAIL = 'admin@veraid.example';

const ORG_NAME = 'example.com';

async function authenticate(clientId: string): Promise<AuthorizationHeader> {
  const body = {
    grant_type: 'client_credentials',
    client_id: clientId,
    client_secret: 's3cr3t',
  };
  const response = await fetch(AUTH_ENDPOINT_URL, {
    method: 'POST',
    headers: new Headers([['Content-Type', 'application/x-www-form-urlencoded']]),
    body: stringify(body),
  });
  const { token_type: scheme, access_token: parameters } = await response.json();
  return { scheme, parameters };
}

test('Create org', async () => {
  const authHeader = await authenticate(ADMIN_EMAIL);
  const client = new AuthorityClient(API_URL, authHeader);

  const command = new OrgCreationCommand({ name: ORG_NAME });
  const org = await client.send(command);

  expect(org.self).toBe(`/orgs/${ORG_NAME}`);
});

```